### PR TITLE
Fixing runtime error in Juicy when "module" is undefined

### DIFF
--- a/Juicy/Juicy.js
+++ b/Juicy/Juicy.js
@@ -441,7 +441,7 @@ Phaser.Plugin.Juicy.prototype.update = function () {
 };
 
 // for browserify compatibility
-if(module && module.exports) {
+if(typeof module === 'object' && module.exports) {
   module.exports = Phaser.Plugin.Juicy;
 }
 


### PR DESCRIPTION
A variable must be defined in order to use in an "if".
